### PR TITLE
Enhance silence indicator animations and fix duplicate markers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Both client and server compile to `dist/` directories:
   - `LyricsContent.tsx`: Actual lyrics rendering with synchronization and word-level highlighting
   - `Player.tsx`: Music playback controls with animated song name
   - `AnimatedSongName.tsx`: Framer Motion component for scrolling song titles
-  - `SilenceIndicator.tsx`: Animated silence detection with configurable timing thresholds
+  - `SilenceIndicator.tsx`: Animated silence detection with cubic easing fade effects (first block fades in/out, middle blocks 1s fade in/out, last block 1s fade in then out)
   - `NoLyricsFound.tsx`: Empty state component for missing lyrics
 - **Player/**: Main application screens and loading states
   - `MainScreen.tsx`: Root screen component with overlay management and universal close button

--- a/client/src/components/LyricsVisualizer/LyricsManager.tsx
+++ b/client/src/components/LyricsVisualizer/LyricsManager.tsx
@@ -75,8 +75,9 @@ const LyricsManager = () => {
       // Silence indicators are already in the LRC content from normalization
       // Mark silence lines with metadata for UI detection
       const linesWithMetadata = data.lines.map((line) => {
-        // Detect silence markers by checking text
-        if (line.text === "♪") {
+        // Detect silence markers by checking text (trim to handle whitespace)
+        const trimmedText = line.text.trim();
+        if (trimmedText === "♪") {
           return {
             ...line,
             type: "silence" as const,

--- a/client/src/components/LyricsVisualizer/SilenceIndicator.tsx
+++ b/client/src/components/LyricsVisualizer/SilenceIndicator.tsx
@@ -147,7 +147,7 @@ const SilenceIndicator: React.FC<SilenceIndicatorProps> = ({
         >
           {/* Background circle */}
           <svg
-            className={`transform ${blockType === "last" ? "rotate-90" : "-rotate-90"}`}
+            className="-rotate-90 transform"
             style={{ width: "100%", height: "100%" }}
             viewBox="0 0 48 48"
           >
@@ -161,8 +161,8 @@ const SilenceIndicator: React.FC<SilenceIndicatorProps> = ({
               strokeDasharray={`${2 * Math.PI * 20}`}
               strokeDashoffset={
                 blockType === "last"
-                  ? `${2 * Math.PI * 20 * (progress / 100)}` // Counter-clockwise: empties as progress increases
-                  : `${2 * Math.PI * 20 * (1 - progress / 100)}` // Clockwise: fills as progress increases
+                  ? `${2 * Math.PI * 20 * (progress / 100)}` // Starts at 0 (full), increases to circumference (empty)
+                  : `${2 * Math.PI * 20 * (1 - progress / 100)}` // Starts at circumference (empty), decreases to 0 (full)
               }
               className={`transition-all duration-300 ${isActive ? "text-white/90" : "text-white/40"}`}
               strokeLinecap="round"

--- a/client/src/components/LyricsVisualizer/SilenceIndicator.tsx
+++ b/client/src/components/LyricsVisualizer/SilenceIndicator.tsx
@@ -11,20 +11,20 @@ interface SilenceIndicatorProps {
   startTime: number;
   /** Duration of the silence period in seconds */
   duration: number;
-  /** Whether this is the first or last silence block (no bounce animation) */
-  isEdgeBlock?: boolean;
+  /** Type of silence block: first (fade in), middle (animated), last (fade out) */
+  blockType?: "first" | "middle" | "last";
 }
 
 /**
  * Animated indicator for instrumental breaks / moments of silence
  * Shows a pulsing musical note icon with a circular progress timer
- * Edge blocks (first/last) don't have bounce animation
+ * First block fades in, middle blocks animate, last block fades out
  */
 const SilenceIndicator: React.FC<SilenceIndicatorProps> = ({
   isActive = false,
   startTime,
   duration,
-  isEdgeBlock = false,
+  blockType = "middle",
 }) => {
   const playerState = useAtomValue(playerStateAtom);
   const [progress, setProgress] = useState(0);
@@ -50,25 +50,83 @@ const SilenceIndicator: React.FC<SilenceIndicatorProps> = ({
     (playerState?.currentTime ? playerState.currentTime - startTime : 0);
   const displayTime = Math.max(Math.ceil(remainingTime), 0);
 
+  // Easing function for smooth fade in/out (ease-in-out cubic)
+  const easeInOutCubic = (t: number): number => {
+    return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+  };
+
+  // Calculate opacity based on block type and progress
+  const fadeOpacity = isActive
+    ? blockType === "first"
+      ? (() => {
+          // First block: fade in over duration, then fade out over last 1s
+          const elapsed = (progress / 100) * duration;
+          const FADE_OUT_DURATION = 1; // 1 second
+
+          if (elapsed > duration - FADE_OUT_DURATION) {
+            // Fade out during last second
+            const t = (duration - elapsed) / FADE_OUT_DURATION;
+            return Math.min(progress / 100, 1) * easeInOutCubic(t);
+          } else {
+            // Normal fade in
+            return Math.min(progress / 100, 1);
+          }
+        })()
+      : blockType === "last"
+        ? (() => {
+            // Last block: fade in over first 1s, then fade out over remaining duration
+            const elapsed = (progress / 100) * duration;
+            const FADE_IN_DURATION = 1; // 1 second
+
+            if (elapsed < FADE_IN_DURATION) {
+              // Fade in during first second
+              const t = elapsed / FADE_IN_DURATION;
+              return easeInOutCubic(t) * Math.max(1 - progress / 100, 0);
+            } else {
+              // Normal fade out
+              return Math.max(1 - progress / 100, 0);
+            }
+          })()
+        : (() => {
+            // Middle blocks: fade in over 1s, full opacity, fade out over 1s
+            const elapsed = (progress / 100) * duration;
+            const FADE_DURATION = 1; // 1 second
+
+            if (elapsed < FADE_DURATION) {
+              // Fade in during first second
+              const t = elapsed / FADE_DURATION;
+              return easeInOutCubic(t);
+            } else if (elapsed > duration - FADE_DURATION) {
+              // Fade out during last second
+              const t = (duration - elapsed) / FADE_DURATION;
+              return easeInOutCubic(t);
+            } else {
+              // Full opacity in between
+              return 1;
+            }
+          })()
+    : 0.3;
+
   return (
     <div
       data-testid="silence-indicator"
       className={`flex items-center justify-center p-3 transition-all duration-300 ${
         isActive
-          ? "opacity-100 [filter:drop-shadow(0_0_2px_#fff)_drop-shadow(0_0_10px_#fff)_drop-shadow(2px_2px_4px_rgba(0,0,0,0.8))]"
-          : "opacity-30"
+          ? "[filter:drop-shadow(0_0_2px_#fff)_drop-shadow(0_0_10px_#fff)_drop-shadow(2px_2px_4px_rgba(0,0,0,0.8))]"
+          : ""
       }`}
+      style={{ opacity: fadeOpacity }}
     >
       <motion.div
         animate={
-          isEdgeBlock
+          blockType === "middle"
             ? {
-                // No bounce for edge blocks, just fade
+                // Normal bounce animation for middle blocks
+                scale: isActive ? [1, 1.3, 1] : [1, 1.2, 1],
                 opacity: isActive ? [0.9, 1, 0.9] : [0.5, 0.7, 0.5],
               }
             : {
-                // Normal bounce animation for middle blocks
-                scale: isActive ? [1, 1.3, 1] : [1, 1.2, 1],
+                // No bounce for first/last blocks, just subtle fade
                 opacity: isActive ? [0.9, 1, 0.9] : [0.5, 0.7, 0.5],
               }
         }
@@ -89,7 +147,7 @@ const SilenceIndicator: React.FC<SilenceIndicatorProps> = ({
         >
           {/* Background circle */}
           <svg
-            className="-rotate-90 transform"
+            className={`transform ${blockType === "last" ? "rotate-90" : "-rotate-90"}`}
             style={{ width: "100%", height: "100%" }}
             viewBox="0 0 48 48"
           >
@@ -101,7 +159,11 @@ const SilenceIndicator: React.FC<SilenceIndicatorProps> = ({
               strokeWidth="2"
               fill="none"
               strokeDasharray={`${2 * Math.PI * 20}`}
-              strokeDashoffset={`${2 * Math.PI * 20 * (1 - progress / 100)}`}
+              strokeDashoffset={
+                blockType === "last"
+                  ? `${2 * Math.PI * 20 * (progress / 100)}` // Counter-clockwise: empties as progress increases
+                  : `${2 * Math.PI * 20 * (1 - progress / 100)}` // Clockwise: fills as progress increases
+              }
               className={`transition-all duration-300 ${isActive ? "text-white/90" : "text-white/40"}`}
               strokeLinecap="round"
             />

--- a/client/src/components/LyricsVisualizer/SilenceLine.tsx
+++ b/client/src/components/LyricsVisualizer/SilenceLine.tsx
@@ -19,10 +19,12 @@ const SilenceLine: React.FC<SilenceLineProps> = ({
   time,
   duration,
   isActive,
-  isEdgeBlock,
   isFirstBlock = false,
   isLastBlock = false,
 }) => {
+  // Determine block type based on position
+  const blockType = isFirstBlock ? "first" : isLastBlock ? "last" : "middle";
+
   return (
     <div
       data-testid="silence-indicator-line"
@@ -56,7 +58,7 @@ const SilenceLine: React.FC<SilenceLineProps> = ({
           isActive={isActive}
           startTime={time}
           duration={duration}
-          isEdgeBlock={isEdgeBlock}
+          blockType={blockType}
         />
       </motion.div>
     </div>

--- a/client/src/utils/lyricsNormalizer.ts
+++ b/client/src/utils/lyricsNormalizer.ts
@@ -181,11 +181,22 @@ export function insertSilenceIndicatorsIntoLrc(
   }
 
   // Check if we need silence indicator at the end
+  // Only add if we haven't already added one in the loop above
   if (sortedTimes.length > 0 && duration !== undefined && duration > 0) {
     const lastTime = sortedTimes[sortedTimes.length - 1];
+    const secondLastTime =
+      sortedTimes.length > 1 ? sortedTimes[sortedTimes.length - 2] : undefined;
     const gapAtEnd = duration - lastTime;
 
-    if (gapAtEnd > DETECTION_THRESHOLD) {
+    // Check if we already added a silence marker for the gap before the last lyric
+    const alreadyHasSilenceBeforeEnd =
+      secondLastTime !== undefined &&
+      lastTime - secondLastTime > DETECTION_THRESHOLD;
+
+    // Only add end silence if:
+    // 1. There's a significant gap at the end, AND
+    // 2. We didn't already add a silence marker right before the last lyric
+    if (gapAtEnd > DETECTION_THRESHOLD && !alreadyHasSilenceBeforeEnd) {
       const silenceStartTime = lastTime + INDICATOR_DELAY;
       const startTimestamp = formatLrcTimestamp(silenceStartTime);
 

--- a/client/tests/e2e/functional/settings.spec.ts
+++ b/client/tests/e2e/functional/settings.spec.ts
@@ -303,12 +303,22 @@ test.describe("Settings Functionality", () => {
       for (const viewport of viewports) {
         await page.setViewportSize(viewport);
 
+        // Ensure settings are closed before starting (in case previous iteration left them open)
+        const settingsScreen = page.locator('[data-testid="settings-screen"]');
+        if (await settingsScreen.isVisible()) {
+          const existingCloseButton = page.locator(
+            '[data-testid="close-overlay-button"]',
+          );
+          await existingCloseButton.click();
+          await expect(settingsScreen).not.toBeVisible();
+        }
+
         // Wait for settings button to be visible before clicking
         const settingsButton = page.locator('[data-testid="settings-button"]');
-        await settingsButton.waitFor({ state: "visible" });
+        await expect(settingsButton).toBeVisible();
         await settingsButton.click();
 
-        await page.waitForSelector('[data-testid="settings-screen"]');
+        await expect(settingsScreen).toBeVisible();
 
         // Settings should be responsive
         await expect(
@@ -322,13 +332,14 @@ test.describe("Settings Functionality", () => {
         // Close settings
         await closeButton.click();
 
-        // Wait for settings to fully close and settings button to reappear
-        await page.waitForSelector('[data-testid="settings-screen"]', {
-          state: "hidden",
-        });
+        // Wait for settings to fully close (animation complete)
+        await expect(settingsScreen).not.toBeVisible();
+
+        // Verify main screen and settings button are back
         await expect(
           page.locator('[data-testid="lyrics-screen"]'),
         ).toBeVisible();
+        await expect(settingsButton).toBeVisible();
       }
     });
   });


### PR DESCRIPTION
## Summary
  - Add sophisticated fade animations to silence indicators with cubic easing
  - Fix duplicate silence marker bug when last lyric has large gap before it
  - Remove circle progress easing for linear animation
  - Last block now empties backwards (starts full, ends empty)
  - Improve E2E test reliability by fixing timing race conditions

  ## Changes

  ### Silence Indicator Animation Enhancements
  - **First block**: Fades in over duration, fades out in last 1s with cubic easing
  - **Middle blocks**: 1s fade in/out with cubic easing, full opacity between
  - **Last block**: 1s fade in with easing, then fades out over duration
  - **Circle progress**: Linear animation (no easing) for consistent timing
  - **Last block circle**: Starts full and empties (reversed from fill behavior)

  ### Bug Fixes
  - Prevent duplicate silence markers when song has big gap before last lyric
  - Trim whitespace when detecting silence markers (♪)
  - Add comprehensive unit test for duplicate detection edge case

  ### Test Improvements
  - Fix accessibility test slider focus issue (keyboard events weren't captured)
  - Add defensive state isolation checks to prevent test pollution
  - Simplify loading screen tests from 3 to 2 focused cases
  - Remove flaky hardcoded timeouts in favor of Playwright retry logic
  - Replace brittle CSS selectors with scoped data-testid selectors

  ## Test plan
  - [x] All 115 unit tests pass
  - [x] E2E accessibility tests pass with proper focus management
  - [x] E2E settings tests handle viewport loops without state pollution
  - [x] E2E loading tests simplified and more reliable
  - [x] Turbo cache working optimally (FULL TURBO)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)