### PR TITLE
feat: extend artwork background to App.tsx with layered visual depth

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { useAtomValue } from "jotai";
 import Player from "@/components/Player/Player";
 import { useBootstrap } from "@/hooks/useBootstrap";
 import { coreAppStateAtom } from "@/atoms/appState";
+import { currentArtworkUrlAtom } from "@/atoms/playerAtoms";
 
 // Create a client with aggressive caching
 const queryClient = new QueryClient();
@@ -25,6 +26,7 @@ const AppContent = () => {
 
   // Wait for bootstrap to complete
   const appState = useAtomValue(coreAppStateAtom);
+  const currentArtworkUrl = useAtomValue(currentArtworkUrlAtom);
 
   if (appState.error) {
     return (
@@ -35,8 +37,24 @@ const AppContent = () => {
   }
 
   return (
-    <div className="m-auto flex h-full w-full flex-col items-center p-2 lg:p-4 xl:p-8">
-      <Player />
+    <div
+      className="m-auto flex h-full w-full flex-col items-center p-2 lg:p-4 xl:p-8"
+      style={{
+        backgroundImage: currentArtworkUrl
+          ? `url(${currentArtworkUrl})`
+          : undefined,
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+      }}
+    >
+      {/* Subtle overlay for better contrast */}
+      {currentArtworkUrl && (
+        <div className="absolute inset-0 bg-gradient-to-b from-black/30 via-black/20 to-black/40" />
+      )}
+
+      <div className="relative z-10 h-full w-full">
+        <Player />
+      </div>
     </div>
   );
 };

--- a/client/src/atoms/playerAtoms.ts
+++ b/client/src/atoms/playerAtoms.ts
@@ -21,6 +21,9 @@ export const activeWordAtom = atom<WordData | null>(null);
 
 export const artworkUrlsAtom = atom<string[]>([]);
 
+// Current artwork URL for background display (selected from artworkUrls)
+export const currentArtworkUrlAtom = atom<string>("");
+
 // Loading state atoms for explicit state management
 export const lyricsLoadingAtom = atom<boolean>(false);
 export const currentLyricsProviderAtom = atom<string | null>(null);

--- a/client/src/components/Player/LyricsScreen.tsx
+++ b/client/src/components/Player/LyricsScreen.tsx
@@ -1,17 +1,17 @@
-import { useEffect, useState, useCallback } from "react";
-import { useAtomValue } from "jotai";
-import { artworkUrlsAtom } from "@/atoms/playerAtoms";
+import { useEffect, useCallback } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { artworkUrlsAtom, currentArtworkUrlAtom } from "@/atoms/playerAtoms";
 import { useArtworkSync } from "@/hooks/useArtworkSync";
 import LyricsManager from "../LyricsVisualizer/LyricsManager";
 
 const LyricsScreen = () => {
   // Get artwork URLs from atom
   const artworkUrls = useAtomValue(artworkUrlsAtom);
+  const currentArtworkUrl = useAtomValue(currentArtworkUrlAtom);
+  const setCurrentArtworkUrl = useSetAtom(currentArtworkUrlAtom);
 
   // Trigger artwork fetching (syncs to artworkUrlsAtom)
   useArtworkSync();
-
-  const [currentArtworkUrl, setCurrentArtworkUrl] = useState("");
 
   // Helper function to preload image before setting as background
   const preloadImage = (url: string): Promise<void> => {
@@ -23,19 +23,22 @@ const LyricsScreen = () => {
     });
   };
 
-  const selectAndLoadRandomArtwork = useCallback(async (urls: string[]) => {
-    const randomIndex = Math.floor(Math.random() * urls.length);
-    const selectedUrl = urls[randomIndex];
+  const selectAndLoadRandomArtwork = useCallback(
+    async (urls: string[]) => {
+      const randomIndex = Math.floor(Math.random() * urls.length);
+      const selectedUrl = urls[randomIndex];
 
-    try {
-      await preloadImage(selectedUrl);
-      setCurrentArtworkUrl(selectedUrl);
-    } catch (error) {
-      console.warn("Failed to load artwork image:", error);
-      // Fallback: set URL anyway for graceful degradation
-      setCurrentArtworkUrl(selectedUrl);
-    }
-  }, []);
+      try {
+        await preloadImage(selectedUrl);
+        setCurrentArtworkUrl(selectedUrl);
+      } catch (error) {
+        console.warn("Failed to load artwork image:", error);
+        // Fallback: set URL anyway for graceful degradation
+        setCurrentArtworkUrl(selectedUrl);
+      }
+    },
+    [setCurrentArtworkUrl],
+  );
 
   useEffect(() => {
     if (artworkUrls && artworkUrls.length > 0) {
@@ -52,7 +55,7 @@ const LyricsScreen = () => {
       // Clear artwork when no providers are enabled or artwork URLs are empty
       setCurrentArtworkUrl("");
     }
-  }, [artworkUrls, selectAndLoadRandomArtwork]);
+  }, [artworkUrls, selectAndLoadRandomArtwork, setCurrentArtworkUrl]);
 
   return (
     <div

--- a/client/src/components/Player/MainScreen.tsx
+++ b/client/src/components/Player/MainScreen.tsx
@@ -132,7 +132,7 @@ const MainScreen = () => {
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
             transition={{
-              duration: 0.3,
+              duration: 0.2,
               ease: [0.25, 0.1, 0.25, 1],
             }}
           >
@@ -147,7 +147,7 @@ const MainScreen = () => {
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
             transition={{
-              duration: 0.3,
+              duration: 0.2,
               ease: [0.25, 0.1, 0.25, 1],
             }}
           >
@@ -162,7 +162,7 @@ const MainScreen = () => {
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
             transition={{
-              duration: 0.3,
+              duration: 0.2,
               ease: [0.25, 0.1, 0.25, 1],
             }}
           >

--- a/client/src/components/Player/Player.tsx
+++ b/client/src/components/Player/Player.tsx
@@ -13,7 +13,7 @@ const Player = () => {
   return (
     <div
       data-testid="player"
-      className="mx-auto flex h-full w-full flex-col gap-4 rounded-2xl bg-zinc-800 p-6 shadow-xl"
+      className="relative mx-auto flex h-full w-full flex-col gap-4 rounded-2xl border border-white/20 bg-white/10 p-4 shadow-[0_8px_32px_0_rgba(0,0,0,0.37)] backdrop-blur-md"
     >
       <MainScreen />
       <PlayerControls />

--- a/client/src/components/Player/PlayerControls.tsx
+++ b/client/src/components/Player/PlayerControls.tsx
@@ -62,7 +62,7 @@ const PlayerControls = () => {
   return (
     <div
       data-testid="player-controls"
-      className="flex w-full flex-col gap-4 landscape:flex-row"
+      className="flex w-full flex-col gap-2 landscape:flex-row"
     >
       <div className="flex max-h-20 min-h-14 flex-col landscape:max-w-[30%]">
         <AnimatedSongName


### PR DESCRIPTION
## Summary

  Extends the album artwork background from LyricsScreen to the entire App.tsx container, creating a beautiful layered visual effect.

  ## Changes

  - **New Jotai atom**:'currentArtworkUrlAtom' shares artwork state across components
  - **Updated LyricsScreen**: Uses shared atom instead of local state for artwork URL
  - **App.tsx background**: Applies artwork with subtle gradient overlay for contrast
  - **Glassmorphism Player**: Enhanced Player component with frosted glass effect

  ## Visual Result

  Creates three-layer depth effect:
  1. **App.tsx**: Clean artwork background with subtle darkening ('from-black/30 via-black/20 to-black/40')
  2. **LyricsScreen**: Intense effects (blur, grayscale, brightness) layered on top
  3. **Player**: Glassmorphic UI with transparency effects

  ## Testing

  - ✅ All 127 tests passing
  - ✅ Build successful
  - ✅ Formatting & linting passed