### PR TITLE
feat(server): add automatic port fallback when default port is busy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ You can run any pnpm command from the root directory by using the `--filter` opt
 ### Individual workspace commands:
 
 - Client: `cd client && pnpm dev` (Vite dev server on port 5173)
-- Server: `cd server && pnpm dev` (Node.js server on port 4000)
+- Server: `cd server && pnpm dev` (Node.js server, attempts ports 4000, 5000, 5173, 8080, 3000, 3001, 4001, 4002 in order)
 
 ### Testing commands:
 
@@ -103,6 +103,7 @@ Both client and server compile to `dist/` directories:
 
 - **Framework**: Hono (lightweight web framework)
 - **Runtime**: Node.js with TypeScript
+- **Port Selection**: Automatically finds available port from [4000, 5000, 5173, 8080, 3000, 3001, 4001, 4002]
 - **Apple Music Integration**: Uses AppleScript via `osascript` to query macOS Music app
 - **WebSocket Server**: Real-time communication using JSON-RPC 2.0 protocol
   - `song.update`: Broadcasts song info only on state changes (song change, play/pause, significant time drift from seeking)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -65,76 +65,136 @@ app.get("/", (c) => c.text("Hello World"));
 
 export { app };
 
+/**
+ * Find an available port from a list of preferred ports
+ * @param preferredPorts Array of ports to try in order
+ * @returns Promise resolving to the first available port
+ */
+async function findAvailablePort(
+  preferredPorts: number[],
+): Promise<number | null> {
+  for (const port of preferredPorts) {
+    const isAvailable = await new Promise<boolean>((resolve) => {
+      const testServer = createServer();
+
+      testServer.once("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "EADDRINUSE") {
+          resolve(false);
+        } else {
+          resolve(false);
+        }
+      });
+
+      testServer.once("listening", () => {
+        testServer.close();
+        resolve(true);
+      });
+
+      testServer.listen(port);
+    });
+
+    if (isAvailable) {
+      return port;
+    }
+  }
+
+  return null;
+}
+
 // Only start server if this file is run directly
 if (require.main === module) {
-  const PORT = 4000;
+  // Preferred ports to try (4000, then common alternatives)
+  const PREFERRED_PORTS = [4000, 5000, 5173, 8080, 3000, 3001, 4001, 4002];
 
-  // Create HTTP server
-  const httpServer = createServer();
+  (async () => {
+    // Find an available port
+    const PORT = await findAvailablePort(PREFERRED_PORTS);
 
-  // Create WebSocket server
-  const wss = new WebSocketServer({ noServer: true });
-
-  // Attach Hono app to HTTP server for regular HTTP requests
-  httpServer.on("request", async (req, res) => {
-    const request = new Request(`http://localhost:${PORT}${req.url}`, {
-      method: req.method,
-      headers: req.headers as Record<string, string>,
-      body:
-        req.method !== "GET" && req.method !== "HEAD"
-          ? await new Promise<string>((resolve) => {
-              let body = "";
-              req.on("data", (chunk) => {
-                body += chunk;
-              });
-              req.on("end", () => resolve(body));
-            })
-          : undefined,
-    });
-
-    const response = await app.fetch(request);
-
-    res.statusCode = response.status;
-    response.headers.forEach((value, key) => {
-      res.setHeader(key, value);
-    });
-
-    if (response.body) {
-      const reader = response.body.getReader();
-      const pump = async () => {
-        const { done, value } = await reader.read();
-        if (done) {
-          res.end();
-          return;
-        }
-        res.write(value);
-        await pump();
-      };
-      await pump();
-    } else {
-      res.end();
+    if (!PORT) {
+      console.error(
+        "❌ Could not find an available port. Tried:",
+        PREFERRED_PORTS.join(", "),
+      );
+      process.exit(1);
     }
-  });
 
-  // Handle WebSocket upgrade requests
-  httpServer.on("upgrade", (request, socket, head) => {
-    const { pathname } = new URL(request.url || "", `ws://localhost:${PORT}`);
+    // Log if we're using a fallback port
+    if (PORT !== PREFERRED_PORTS[0]) {
+      console.log(
+        `⚠️  Port ${PREFERRED_PORTS[0]} is in use, using port ${PORT} instead`,
+      );
+    }
 
-    if (pathname === "/ws") {
-      wss.handleUpgrade(request, socket, head, (ws) => {
-        wss.emit("connection", ws, request);
+    // Create HTTP server
+    const httpServer = createServer();
+
+    // Create WebSocket server
+    const wss = new WebSocketServer({ noServer: true });
+
+    // Attach Hono app to HTTP server for regular HTTP requests
+    httpServer.on("request", async (req, res) => {
+      const request = new Request(`http://localhost:${PORT}${req.url}`, {
+        method: req.method,
+        headers: req.headers as Record<string, string>,
+        body:
+          req.method !== "GET" && req.method !== "HEAD"
+            ? await new Promise<string>((resolve) => {
+                let body = "";
+                req.on("data", (chunk) => {
+                  body += chunk;
+                });
+                req.on("end", () => resolve(body));
+              })
+            : undefined,
       });
-    } else {
-      socket.destroy();
-    }
-  });
 
-  // Setup WebSocket handlers
-  setupWebSocket(wss);
+      const response = await app.fetch(request);
 
-  // Start server
-  httpServer.listen(PORT, () => {
-    console.log(`Server running on http://localhost:${PORT}`);
-    console.log(`WebSocket server running on ws://localhost:${PORT}/ws`);
+      res.statusCode = response.status;
+      response.headers.forEach((value, key) => {
+        res.setHeader(key, value);
+      });
+
+      if (response.body) {
+        const reader = response.body.getReader();
+        const pump = async () => {
+          const { done, value } = await reader.read();
+          if (done) {
+            res.end();
+            return;
+          }
+          res.write(value);
+          await pump();
+        };
+        await pump();
+      } else {
+        res.end();
+      }
+    });
+
+    // Handle WebSocket upgrade requests
+    httpServer.on("upgrade", (request, socket, head) => {
+      const { pathname } = new URL(request.url || "", `ws://localhost:${PORT}`);
+
+      if (pathname === "/ws") {
+        wss.handleUpgrade(request, socket, head, (ws) => {
+          wss.emit("connection", ws, request);
+        });
+      } else {
+        socket.destroy();
+      }
+    });
+
+    // Setup WebSocket handlers
+    setupWebSocket(wss);
+
+    // Start server
+    httpServer.listen(PORT, () => {
+      console.log(`✅ Server running on http://localhost:${PORT}`);
+      console.log(`✅ WebSocket server running on ws://localhost:${PORT}/ws`);
+    });
+  })().catch((error) => {
+    console.error("❌ Failed to start server:", error);
+    process.exit(1);
   });
 }


### PR DESCRIPTION
Implement intelligent port selection that automatically finds an available port when the default port 4000 is already in use, preventing startup failures.

Changes:
- Add findAvailablePort() utility function that tests ports sequentially
- Try ports in order: 4000, 5000, 5173, 8080, 3000, 3001, 4001, 4002
- Wrap server startup in async IIFE to support async port detection
- Display helpful warning when using fallback port
- Display error and exit gracefully if no ports available
- Update CLAUDE.md documentation with port selection behavior

This resolves EADDRINUSE errors when port 4000 is occupied by other services, improving developer experience by automatically selecting an alternative port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)